### PR TITLE
fix issue

### DIFF
--- a/src/main/java/net/yxiao233/mekanismupgradesreborn/Config.java
+++ b/src/main/java/net/yxiao233/mekanismupgradesreborn/Config.java
@@ -12,16 +12,19 @@ public class Config {
     private static final ForgeConfigSpec.IntValue ELECTRICITY_MULTIPLIER = BUILDER.comment("Base factor for machine power consumption with upgrades[default:1]").defineInRange("electricity_multiplier",1,1,Integer.MAX_VALUE);
     private static final ForgeConfigSpec.IntValue CAPACITY_MULTIPLIER = BUILDER.comment("Base factor for machine capacity with upgrades[default:1]").defineInRange("capacity_multiplier",1,1,Integer.MAX_VALUE);
     private static final ForgeConfigSpec.IntValue MAX_UPGRADE = BUILDER.comment("Maximum speed/energy upgrades a machine can accept[default:16]").defineInRange("max_upgrade",16,1,64);
+    private static final ForgeConfigSpec.BooleanValue USE_MEK_DEFAULT_ENERGY_AND_SPEED_FORMULA = BUILDER.comment("Use mekanism's default upgrade formula to avoid upgrade 'invalid' when 8 < speedUpgrades < energyUpgrades [default:false]").define("use_mek_default_formula",false);
     static final ForgeConfigSpec SPEC = BUILDER.build();
     public static int timeMultiplier;
     public static int electricityMultiplier;
     public static int capacityMultiplier;
     public static int maxUpgrade;
+    public static boolean useMekDefaultUpgradeFormula;
     @SubscribeEvent
     static void onLoad(final ModConfigEvent event){
         timeMultiplier = TIME_MULTIPLIER.get();
         electricityMultiplier = ELECTRICITY_MULTIPLIER.get();
         capacityMultiplier = CAPACITY_MULTIPLIER.get();
         maxUpgrade = MAX_UPGRADE.get();
+        useMekDefaultUpgradeFormula = USE_MEK_DEFAULT_ENERGY_AND_SPEED_FORMULA.get();
     }
 }

--- a/src/main/java/net/yxiao233/mekanismupgradesreborn/common/Utils.java
+++ b/src/main/java/net/yxiao233/mekanismupgradesreborn/common/Utils.java
@@ -15,7 +15,7 @@ public class Utils {
     public static double electricity(IUpgradeTile tile) {
         var speed = tile.getComponent().getUpgrades(Upgrade.SPEED);
         var energy = tile.getComponent().getUpgrades(Upgrade.ENERGY);
-        return Math.pow(MekanismConfig.general.maxUpgradeMultiplier.get() * Config.electricityMultiplier, (2 * speed - Math.min(energy, Math.max(8, speed))) / 8D);
+        return Math.pow(MekanismConfig.general.maxUpgradeMultiplier.get() * Config.electricityMultiplier, (2 * speed - energy) / 8D);
     }
 
     public static double capacity(IUpgradeTile tile) {

--- a/src/main/java/net/yxiao233/mekanismupgradesreborn/common/Utils.java
+++ b/src/main/java/net/yxiao233/mekanismupgradesreborn/common/Utils.java
@@ -5,6 +5,8 @@ import mekanism.common.config.MekanismConfig;
 import mekanism.common.tile.interfaces.IUpgradeTile;
 import net.yxiao233.mekanismupgradesreborn.Config;
 
+import static net.yxiao233.mekanismupgradesreborn.Config.useMekDefaultUpgradeFormula;
+
 public class Utils {
 
     public static double time(IUpgradeTile tile) {
@@ -15,7 +17,10 @@ public class Utils {
     public static double electricity(IUpgradeTile tile) {
         var speed = tile.getComponent().getUpgrades(Upgrade.SPEED);
         var energy = tile.getComponent().getUpgrades(Upgrade.ENERGY);
-        return Math.pow(MekanismConfig.general.maxUpgradeMultiplier.get() * Config.electricityMultiplier, (2 * speed - energy) / 8D);
+        if (useMekDefaultUpgradeFormula){
+            return Math.pow(MekanismConfig.general.maxUpgradeMultiplier.get() * Config.electricityMultiplier, (2 * speed - energy) / 8D);
+        }
+        return Math.pow(MekanismConfig.general.maxUpgradeMultiplier.get() * Config.electricityMultiplier, (2 * speed - Math.min(energy, Math.max(8, speed))) / 8D);
     }
 
     public static double capacity(IUpgradeTile tile) {


### PR DESCRIPTION
原mek使用的指数:(2*speed - energy)/8   (speed是速度升级数量，energy是能量升级数量,8是原mek最大升级数量，当然人家没写死)
但搬过来的时候Mekanism Tweakers作者用的是(2 * speed - Math.min(energy, Math.max(8, speed))/8

这是一个意味不明的函数，导致了下列问题:
        //issue according to https://www.mcmod.cn/class/17706.html "14楼"
        //{
        //    "user": {
        //        "id": "476946",
        //        "name": "UepERae",
        //        "avatar": {
        //            "img": "//i.mcmod.cn/user/avatar/47/476946/476946_1695983827_LhGy.png@60x60.jpg"
        //        },
        //        "sp": 0,
        //        "lv": 1,
        //        "wap": true
        //    },
        //    "floor": "14楼",
        //    "id": "1936136",
        //    "time": {
        //        "source": "2025-12-27 20:58:51",
        //        "range": "1月前"
        //    },
        //    "attitude": {
        //        "up": 0,
        //        "grintears": 0,
        //        "heart": 0,
        //        "flushed": 0,
        //        "down": 0,
        //        "lemon": 0,
        //        "horsehead": 0,
        //        "heartbroken": 0,
        //        "angry": 0,
        //        "tired": 0,
        //        "snowflake": 0,
        //        "handshake": 0
        //    },
        //    "report": 1,
        //    "reply_count": "1",
        //    "content": "<p>请问一下，在8&lt;速度升级数＜能量升级数时，多余的能量升级不减少能量消耗的bug可不可以尝试修复</p>"
        //}
        
        

为方便起见，画图分析:
https://www.geogebra.org/3d
我们使用下列公式(其中m和M不要打开显示):
m(a,b)=((a+b-abs(a-b))/(2))
M(a,b)=((a+b+abs(a-b))/(2))
g(E,S)=2 S-E
f(E,S)=2 S-m(E,M(8,S))
便可以看到升级带来的能量指数图像（当然了我没有/8）。
其中g(E,S)是原来的指数的图像，f(E,S)是被那个作者修改后的指数的图像
为了方便记得把x轴改成E，y轴改成S